### PR TITLE
[정리은]sprint3

### DIFF
--- a/스프린트 미션/login.css
+++ b/스프린트 미션/login.css
@@ -26,7 +26,8 @@ main {
     border-radius: 12px;
     font-size: 16px;
     line-height: 26px;
-    border: none;
+    border: 2px solid transparent;
+    margin-top: 12px;
   }
   input:focus {
     outline-color: #3692FF;
@@ -36,6 +37,16 @@ main {
     background-repeat: no-repeat;
     background-size: 24px;
     background-position: 95% center;
+  }
+  input.error {
+    border-color: red;
+  }
+  .error-message {
+    color: red;
+    display: none; 
+    margin-top: 5px;
+    margin-left: 12px;
+    font-size: 17px;
   }
 .login-btn {
     width: 95%;

--- a/스프린트 미션/login.html
+++ b/스프린트 미션/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,17 +12,19 @@
             <a href="index.html"><img src="images/logo/panda-market-logo.png"
                 alt="판다마켓 로고"></a>
         </div>
-        <div  class="section-box">
+        <form  class="section-box">
             <div class="panda-txt">
-                <p> 이메일</p>
-                <input type="text" placeholder="이메일을 입력해주세요">
-            </div>
+                <label>이메일</label>
+                <input type="text" id="email" placeholder="이메일을 입력해주세요">
+                <div id="error-message" class="error-message">잘못된 이메일 형식입니다</div>
+             </div>
             <div class="panda-txt">
-                <p>비밀번호</p>
-                <input type="password" placeholder="비밀번호를 입력해주세요" id="pass">
+                <label>비밀번호</label>
+                <input type="password" class="password" placeholder="비밀번호를 입력해주세요" id="pass">
+                <div id="password-error-message" class="error-message">비밀번호를 입력해주세요</div>
             </div>
-            <button class="login-btn">
-                <a class="login-font">로그인</a>
+            <button class="login-btn" id="loginButton">
+                <span class="login-font">로그인</span>
             </button>
             <div class="login-box">
                 <p class="easy-login">간편 로그인하기</p>
@@ -35,7 +37,8 @@
                 <a class="first">판다마켓이 처음이신가요?&nbsp; </a>
                 <a class="login-signup" href="signup.html">회원가입</a>
             </div>
-        </div>
+        </form>
     </main>
+    <script src="login.js"></script>
 </body>
 </html>

--- a/스프린트 미션/login.js
+++ b/스프린트 미션/login.js
@@ -1,0 +1,84 @@
+const USER_DATA = [
+    { email: 'codeit1@codeit.com', password: "codeit101!" },
+    { email: 'codeit2@codeit.com', password: "codeit202!" },
+    { email: 'codeit3@codeit.com', password: "codeit303!" },
+    { email: 'codeit4@codeit.com', password: "codeit404!" },
+    { email: 'codeit5@codeit.com', password: "codeit505!" },
+    { email: 'codeit6@codeit.com', password: "codeit606!" },
+];
+
+const emailInput = document.getElementById('email');
+const errorMessage = document.getElementById('error-message');
+const passwordInput = document.getElementById('pass');
+const passwordErrorMessage = document.getElementById('password-error-message');
+const confirmPasswordInput = document.querySelector('.confirm-pass'); 
+const loginButton = document.getElementById('loginButton');
+
+const emailPattern = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
+
+function validateInputs() {
+    const emailValue = emailInput.value.trim();
+    const passwordValue = passwordInput.value.trim();
+    const emailIsValid = emailPattern.test(emailValue) && emailValue !== '';
+    const passwordIsValid = passwordValue.length >= 8;
+
+    if (emailIsValid && passwordIsValid) {
+        loginButton.classList.add('active');
+    } else {
+        loginButton.classList.remove('active');
+    }
+}
+
+emailInput.addEventListener('focusout', function(e) {
+    const emailValue = e.target.value.trim();
+
+    if (emailValue === '') {
+        e.target.classList.add('error'); 
+        errorMessage.style.display = 'block'; 
+        errorMessage.textContent = '이메일을 입력해주세요'; 
+    } else if (emailPattern.test(emailValue)) {
+        e.target.classList.remove('error'); 
+        errorMessage.style.display = 'none';
+    } else {
+        e.target.classList.add('error');
+        errorMessage.style.display = 'block'; 
+        errorMessage.textContent = '잘못된 이메일 형식입니다'; 
+    }
+});
+passwordInput.addEventListener('focusout', function(e) {
+    const passwordValue = e.target.value.trim();
+
+    const isValidPassword = passwordValue.length >= 8; 
+
+    if (passwordValue === '') {
+        e.target.classList.add('error'); 
+        passwordErrorMessage.style.display = 'block'; 
+        passwordErrorMessage.textContent = '비밀번호를 입력해 주세요.';
+    } else if (!isValidPassword) {
+        e.target.classList.add('error');
+        passwordErrorMessage.style.display = 'block'; 
+        passwordErrorMessage.textContent = '비밀번호는 8자 이상이어야 합니다.';
+    } else {
+        e.target.classList.remove('error');
+        passwordErrorMessage.style.display = 'none'; 
+    }
+    validateInputs();
+});
+
+loginButton.addEventListener('click', function(e) {
+    const emailValue = emailInput.value.trim();
+    const passwordValue = passwordInput.value.trim();
+
+    const user = USER_DATA.find(user => user.email === emailValue);
+
+    if (!user) {
+        alert('이메일이 존재하지 않습니다.');
+    } else if (user.password !== passwordValue) {
+        alert('비밀번호가 일치하지 않습니다.');
+    } else {
+        window.location.href = '/items';
+    }
+});
+
+
+loginButton.classList.remove('active');

--- a/스프린트 미션/signup.html
+++ b/스프린트 미션/signup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,26 +14,29 @@
         </div>
         <div class="section-box">
             <div class="panda-txt">
-                <p> 이메일</p>
-                <input type="text" placeholder="이메일을 입력해주세요">
+                <label> 이메일</label>
+                <input type="text" id="email" placeholder="이메일을 입력해주세요">
+                <div id="error-message" class="error-message">잘못된 이메일 형식입니다</div>
             </div>
             <div class="panda-txt">
-                <p>닉네임</p>
+                <label>닉네임</label>
                 <input type="text" placeholder="닉네임을 입력해주세요">
             </div>
             <div class="panda-txt">
-                <p>비밀번호</p>
+                <label>비밀번호</label>
                 <input type="password" placeholder="비밀번호를 입력해주세요" id="pass">
+                <div id="password-error-message" class="error-message"></div>
             </div>
             <div class="panda-txt">
-                <p>비밀번호 확인</p>
-                <input type="password" placeholder="비밀번호를 다시 한 번 입력해주세요" id="pass">
+                <label>비밀번호 확인</label>
+                <input type="password" class="confirm-pass" placeholder="비밀번호를 다시 한 번 입력해주세요" id="confirm-pass">
+                <div id="confirm-password-error-message" class="error-message">비밀번호가 일치하지 않습니다.</div>
             </div>
-            <button class="login-btn">
-                <a class="login-font">회원가입</a>
+            <button class="login-btn" id="loginButton">
+                <span class="login-font">회원가입</span>
             </button>
             <div class="login-box">
-                <p class="easy-login">간편 로그인하기</p>
+                <label class="easy-login">간편 로그인하기</label>
                 <div>
                     <a href="https://www.google.com/"><img src="images/구글.png"></a>
                     <a href="https://www.kakaocorp.com/page/"><img src="images/카톡.png"></a>
@@ -45,5 +48,6 @@
             </div>
         </div>
     </main>
+    <script src="signup.js"></script>
 </body>
 </html>

--- a/스프린트 미션/signup.js
+++ b/스프린트 미션/signup.js
@@ -1,0 +1,100 @@
+const USER_DATA = [
+    { email: 'codeit1@codeit.com', password: "codeit101!" },
+    { email: 'codeit2@codeit.com', password: "codeit202!" },
+    { email: 'codeit3@codeit.com', password: "codeit303!" },
+    { email: 'codeit4@codeit.com', password: "codeit404!" },
+    { email: 'codeit5@codeit.com', password: "codeit505!" },
+    { email: 'codeit6@codeit.com', password: "codeit606!" },
+];
+
+const emailInput = document.getElementById('email');
+const errorMessage = document.getElementById('error-message');
+const passwordInput = document.getElementById('pass');
+const passwordErrorMessage = document.getElementById('password-error-message');
+const confirmPasswordInput = document.querySelector('.confirm-pass');
+const confirmPasswordErrorMessage = document.getElementById('confirm-password-error-message');
+const loginButton = document.getElementById('loginButton');
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validateInputs() {
+    const emailValue = emailInput.value.trim();
+    const passwordValue = passwordInput.value.trim();
+    const passwordIsValid = passwordValue.length >= 8;
+    const emailIsValid = emailPattern.test(emailValue) && emailValue !== '';
+
+    if (emailIsValid && passwordIsValid && passwordValue === confirmPasswordInput.value.trim()) {
+        loginButton.classList.add('active');
+        loginButton.disabled = false;
+    } else {
+        loginButton.classList.remove('active');
+        loginButton.disabled = true; 
+    }
+}
+
+emailInput.addEventListener('input', validateInputs);
+passwordInput.addEventListener('input', validateInputs);
+confirmPasswordInput.addEventListener('input', validateInputs);
+
+
+emailInput.addEventListener('input', function(e) {
+    const emailValue = e.target.value.trim();
+
+    if (emailValue === '') {
+        e.target.classList.add('error'); 
+        errorMessage.style.display = 'block'; 
+        errorMessage.textContent = '이메일을 입력해주세요'; 
+    } else if (emailPattern.test(emailValue)) {
+        e.target.classList.remove('error'); 
+        errorMessage.style.display = 'none';
+    } else {
+        e.target.classList.add('error');
+        errorMessage.style.display = 'block'; 
+        errorMessage.textContent = '잘못된 이메일 형식입니다'; 
+    }
+});
+passwordInput.addEventListener('input', function(e) {
+    const passwordValue = passwordInput.value.trim();
+
+    const isValidPassword = passwordValue.length >= 8; 
+
+    if (passwordValue === '') {
+        e.target.classList.add('error'); 
+        passwordErrorMessage.style.display = 'block'; 
+        passwordErrorMessage.textContent = '비밀번호를 입력해 주세요.';
+    } else if (!isValidPassword) {
+        e.target.classList.add('error');
+        passwordErrorMessage.style.display = 'block'; 
+        passwordErrorMessage.textContent = '비밀번호는 8자 이상이어야 합니다.';
+    } else {
+        e.target.classList.remove('error');
+        passwordErrorMessage.style.display = 'none'; 
+    }
+    validateInputs();
+});
+
+function validatePasswordMatch() {
+    if (passwordInput.value === confirmPasswordInput.value && confirmPasswordInput.value !== '') {
+        confirmPasswordInput.classList.remove('error');
+        confirmPasswordErrorMessage.style.display = 'none'; 
+    } else {
+        confirmPasswordInput.classList.add('error');
+        confirmPasswordErrorMessage.style.display = 'block';
+    }
+}
+
+passwordInput.addEventListener('input', validatePasswordMatch);
+confirmPasswordInput.addEventListener('input', validatePasswordMatch);
+
+loginButton.addEventListener('click', function() {
+    const emailValue = emailInput.value.trim();
+    
+    const emailExists = USER_DATA.some(user => user.email === emailValue);
+    
+    if (emailExists) {
+        alert('사용 중인 이메일입니다.');
+    } else {
+        alert('회원가입이 완료되었습니다! 로그인 페이지로 이동합니다.');
+        window.location.href = "login.html"; 
+    }
+});


### PR DESCRIPTION
## 요구사항

### 기본 요구사항

공통

[ ] Github에 스프린트 미션 PR을 만들어 주세요.
로그인, 회원가입 페이지 공통

[ ] 로그인 및 회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요.
[ ] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
[ ] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
[ ] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
[ ] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
[ ] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
[ ] Input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
[ ] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다
const USER_DATA = [
    { email: 'codeit1@codeit.com', password: "codeit101!" },
    { email: 'codeit2@codeit.com', password: "codeit202!" },
    { email: 'codeit3@codeit.com', password: "codeit303!" },
    { email: 'codeit4@codeit.com', password: "codeit404!" },
    { email: 'codeit5@codeit.com', password: "codeit505!" },
    { email: 'codeit6@codeit.com', password: "codeit606!" },
];
로그인 페이지

[ ] 이메일과 비밀번호를 입력하고 로그인 버튼을 누른 후, 다음 조건을 참조하여 로그인 성공 여부를 alert 메시지로 출력합니다.
만약 입력한 이메일이 데이터베이스(USER_DATA)에 없거나, 이메일은 일치하지만 비밀번호가 틀린 경우, '비밀번호가 일치하지 않습니다.'라는 메시지를 alert로 표시합니다
만약 입력한 이메일이 데이터베이스에 존재하고, 비밀번호도 일치할 경우, “/items”로 이동합니다.
회원가입

[ ] 회원가입을 위해 이메일, 닉네임, 비밀번호, 비밀번호 확인을 입력한 뒤, 회원가입 버튼을 클릭하세요. 그 후에는 다음 조건에 따라 회원가입 가능 여부를 alert로 알려주세요.
입력한 이메일이 이미 데이터베이스(USER_DATA)에 존재하는 경우, '사용 중인 이메일입니다'라는 메시지를 alert로 표시합니다.
입력한 이메일이 데이터베이스(USER_DATA)에 없는 경우, 회원가입이 성공적으로 처리되었으므로 로그인 페이지(”/login”)로 이동합니다.

### 심화 요구사항

- [x]
- []

## 주요 변경사항

공통

[ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 판다마켓 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정합니다.
[ ] 미리보기에서 제목은 “판다마켓”, 설명은 “일상에서 모든 물건을 거래해보세요”로 설정합니다.
[ ] 주소와 이미지는 자유롭게 설정하세요.
[ ] 로그인, 회원가입 페이지에 공통으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용해 주세요.
랜딩 페이지

[ ] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 744px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 743px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다
[ ] Tablet 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
[ ] Mobile 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
[ ] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용합니다.
[ ] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차게 구현합니다. (이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)
[ ] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 사이 간격이 커집니다.
로그인, 회원가입 페이지 공통

[ ] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
[ ] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
[ ] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.
[ ] 오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.
[ ] 비밀번호 및 비밀번호 확인 입력란에 눈 모양 아이콘 클릭 시 비밀번호 표시/숨기기 토글이 가능합니다. 기본 상태는 비밀번호 숨김으로 설정합니다.


## 멘토에게

저번미션에서 말씀해주신 부분을 수정하여 미션 3을 해보았습니다
심화요구사항은 아직 하지 못해서 많이 부족하지만 확인부탁드립니다!
