### PR TITLE
[하신혜] Sprint 3

### DIFF
--- a/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/index.html
+++ b/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="kr">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/join.js
+++ b/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/join.js
@@ -1,8 +1,0 @@
-document.querySelectorAll('.toggle-password').forEach(function(button) {
-  button.addEventListener('click', function() {
-      const passwordInput = this.previousElementSibling; 
-      const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
-      passwordInput.setAttribute('type', type);
-      this.querySelector('img').alt = type === 'password' ? '토글패스워드' : '비밀번호 숨기기';
-  });
-});

--- a/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/login.html
+++ b/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="kr">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -19,19 +19,21 @@
         <div class="input-group1">
             <div class="putemail">
               <input type="email" id="email" placeholder="이메일을 입력해주세요" required>
+              <span class="error-message-mail" id="emailError"></span>
             </div>
         </div>
         <div class="tinyhead">비밀번호</div>
         <div class="input-group2">
             <input type="password" id="password" placeholder="비밀번호를 입력해주세요" required>
+            <span class="error-message-password" id="passwordError"></span>
             <button type="button" class="toggle-password"> <img src="btn_visibility_on_24px.png" alt="토글패스워드">
             </button>
-        </div>
 
-        <button type="submit" class="login-btn">로그인</button>
+          </div>
 
+        <button type="submit" class="login-btn" disabled>로그인</button>
         <div class="easylogin">
-          
+      
         </div>
 
         <div class="social-login">
@@ -43,11 +45,22 @@
           
         </div>
 
+        
+
         <p class="signup-link">
-            판다마켓 처음이신가요? <a href="join.html">회원가입</a>
+            판다마켓 처음이신가요? <a href="register.html">회원가입</a>
         </p>
     </form>
 </div>
+<div id="modal" class="modal">
+  <div class="modal-content">
+    <p id="modalMessage" class="modalmessage">모달 내용</p>
+    <div class="modal-footer">
+      <button class="close-modal-btn">확인</button> 
+    </div>
+  </div>
+</div>
+
 
 <script src="login.js"></script>
 </body>

--- a/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/login.js
+++ b/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/login.js
@@ -1,3 +1,4 @@
+//비밀번호 토글 버튼
 document.querySelector('.toggle-password').addEventListener('click', function () {
   const passwordInput = document.getElementById('password');
   const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
@@ -5,3 +6,173 @@ document.querySelector('.toggle-password').addEventListener('click', function ()
   
   this.querySelector('img').alt = type === 'password' ? '토글패스워드' : '비밀번호 숨기기';
 });
+
+//이메일 입력 칸 
+document.getElementById('email').addEventListener('focusout', function() {
+  const emailInput = document.getElementById('email');
+  const errorMessage = document.getElementById('emailError');
+  const emailValue = emailInput.value.trim();
+  const emailPattern = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+  if (emailValue === "") {
+      emailInput.classList.add('error');
+      errorMessage.textContent = '이메일을 입력해주세요.';
+      errorMessage.style.visibility = 'visible';
+  } else if (!emailPattern.test(emailValue)) {
+      emailInput.classList.add('error');
+      errorMessage.textContent = '잘못된 이메일 형식입니다.';
+      errorMessage.style.visibility = 'visible';
+  } else {
+      emailInput.classList.remove('error');
+      errorMessage.style.visibility = 'hidden';
+  }
+});
+
+//비밀번호 입력 칸
+document.getElementById('password').addEventListener('focusout', function() {
+  const passwordInput = document.getElementById('password');
+  const errorMessage = document.getElementById('passwordError');
+  const passwordValue = passwordInput.value.trim();
+
+ // 비밀번호의 최소 길이를 검사 (8자 이상)
+ if (passwordValue === "") {
+  passwordInput.classList.add('error');
+  errorMessage.textContent = '비밀번호를 입력해주세요.';
+  errorMessage.style.visibility = 'visible';
+} else if (passwordValue.length < 8) {
+  passwordInput.classList.add('error');
+  errorMessage.textContent = '비밀번호를 8자 이상 입력해주세요.';
+  errorMessage.style.visibility = 'visible';
+} else {
+  passwordInput.classList.remove('error');
+  errorMessage.style.visibility = 'hidden';
+}
+});
+
+function validateForm() {
+  const emailInput = document.getElementById('email');
+  const passwordInput = document.getElementById('password');
+  const loginButton = document.querySelector('.login-btn'); 
+  
+  const emailValue = emailInput.value.trim();
+  const passwordValue = passwordInput.value.trim();
+
+  const emailError = document.getElementById('emailError');
+  const passwordError = document.getElementById('passwordError');
+  
+  const emailPattern = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+  
+  let isValid = true;
+
+  // 이메일 유효성 검사
+  if (emailValue === "") {
+      emailInput.classList.add('error');
+      emailError.textContent = '이메일을 입력해주세요.';
+      emailError.style.visibility = 'visible';
+      isValid = false;
+  } else if (!emailPattern.test(emailValue)) {
+      emailInput.classList.add('error');
+      emailError.textContent = '잘못된 이메일 형식입니다.';
+      emailError.style.visibility = 'visible';
+      isValid = false;
+  } else {
+      emailInput.classList.remove('error');
+      emailError.style.visibility = 'hidden';
+  }
+
+  // 비밀번호 유효성 검사
+  if (passwordValue === "") {
+      passwordInput.classList.add('error');
+      passwordError.textContent = '비밀번호를 입력해주세요.';
+      passwordError.style.visibility = 'visible';
+      isValid = false;
+  } else if (passwordValue.length < 8) {
+      passwordInput.classList.add('error');
+      passwordError.textContent = '비밀번호를 8자 이상 입력해주세요.';
+      passwordError.style.visibility = 'visible';
+      isValid = false;
+  } else {
+      passwordInput.classList.remove('error');
+      passwordError.style.visibility = 'hidden';
+  }
+
+  // 로그인 버튼 활성화/비활성화
+  loginButton.disabled = !isValid;
+}
+
+// 이메일과 비밀번호 입력 필드에서 입력할 때마다 유효성 검사를 호출
+document.getElementById('email').addEventListener('input', validateForm);
+document.getElementById('password').addEventListener('input', validateForm);
+
+// focusout 이벤트 시에도 유효성 검사 호출
+document.getElementById('email').addEventListener('focusout', validateForm);
+document.getElementById('password').addEventListener('focusout', validateForm);
+
+// 로그인 버튼 클릭 이벤트 추가
+document.querySelector('.login-btn').addEventListener('click', function() {
+  const loginButton = document.querySelector('.login-btn'); // 클래스 선택자로 변경
+  
+  // 버튼이 활성화되어 있을 때만 이동
+  if (!loginButton.disabled) {
+      window.location.href = '/items'; // '/items'로 페이지 이동
+  }
+  });
+
+
+  // 유저 데이터베이스 (이미 존재하는 이메일과 비밀번호)
+const USER_DATA = [
+  { email: 'codeit1@codeit.com', password: 'codeit101!' },
+  { email: 'codeit2@codeit.com', password: 'codeit202!' },
+  { email: 'codeit3@codeit.com', password: 'codeit303!' },
+  { email: 'codeit4@codeit.com', password: 'codeit404!' },
+  { email: 'codeit5@codeit.com', password: 'codeit505!' },
+  { email: 'codeit6@codeit.com', password: 'codeit606!' }
+];
+
+// 로그인 처리 함수
+function handleLogin() {
+  const emailInput = document.getElementById('email').value.trim();
+  const passwordInput = document.getElementById('password').value.trim();
+
+  // 유저 데이터베이스에서 이메일과 비밀번호 찾기
+  const user = USER_DATA.find(user => user.email === emailInput);
+
+  if (!user) {
+    // 이메일이 데이터베이스에 없는 경우
+    openModal('비밀번호가 일치하지 않습니다.');
+  } else if (user.password !== passwordInput) {
+    // 이메일은 있지만 비밀번호가 틀린 경우
+    openModal('비밀번호가 일치하지 않습니다.');
+  } else {
+    // 이메일과 비밀번호가 모두 일치하는 경우
+    window.location.href = '/login'; // 페이지 이동
+  }
+}
+// 모달 요소 가져오기
+const modal = document.getElementById('modal');
+const modalMessage = document.getElementById('modalMessage');
+const closeModalButton = document.querySelector('.close-modal-btn');
+
+// 모달 열기 함수
+function openModal(message) {
+  modalMessage.textContent = message;
+  modal.style.display = 'block'; // 모달을 보이게 설정
+}
+
+// 모달 닫기 함수 (확인 버튼 클릭 시)
+closeModalButton.addEventListener('click', function () {
+  modal.style.display = 'none';
+});
+
+// 배경 클릭으로 모달 닫기
+window.addEventListener('click', function (event) {
+  if (event.target === modal) {
+    modal.style.display = 'none';
+  }
+});
+
+
+
+
+// 로그인 버튼 클릭 시 실행
+document.querySelector('.login-btn').addEventListener('click', handleLogin);

--- a/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/login_style.css
+++ b/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/login_style.css
@@ -20,7 +20,7 @@ body {
   border-radius: 10px;
   text-align: center;
   width: 640px;
-}
+} 
 
 .logo-section {
   margin-bottom: 30px;
@@ -71,6 +71,37 @@ body {
   justify-content: space-between;
 }
 
+.input-group1 input.error {
+  border: 1px solid red;
+}
+
+.error-message-mail {
+  font-family: 'Pretendard';
+  display: flex;
+  justify-content: space-between;
+  color: #F74747;
+  font-size: 15px;
+  visibility: hidden;
+  margin-top: 8px;
+  line-height: 17.9px;
+  font-weight: 600;
+}
+
+.error-message-password {
+  font-family: 'Pretendard';
+  display: flex;
+  justify-content: space-between;
+  color: #F74747;
+  font-size: 15px;
+  visibility: hidden;
+  margin-top: 8px;
+  line-height: 17.9px;
+  font-weight: 600;
+  position: absolute;
+  bottom: -20px;
+}
+
+
 .input-group1 input:focus {
   outline: none;
   border: 1px solid #3692ff;
@@ -109,11 +140,13 @@ input[type="password"] {
   outline: none;
 }
 
-.input-group2 input:focus {
-  outline: none;
-  border: 1px solid #3692ff;
+input[type="password"] {
+  padding-right: 40px; /* 토글 버튼이 겹치지 않도록 여유 공간 추가 */
 }
 
+.input-group2 input:focus {
+  outline: none;}
+ 
 .toggle-password {
   background: none;
   border: none;
@@ -130,7 +163,7 @@ input[type="password"] {
 .login-btn {
   width: 640px;
   height: 56px;
-  background-color: #9CA3AF;
+  background-color: #3692FF;
   font-family: 'Pretendard';
   color: white;
   font-size: 20px;
@@ -142,8 +175,13 @@ input[type="password"] {
   cursor: pointer;
   margin-bottom: 20px;
   border-radius: 40px;
-  margin-top: 24px;
+  margin-top: 30px;
 }
+
+.login-btn:disabled {
+  background-color: #9CA3AF;
+  cursor: not-allowed;
+} 
 
 .social-login {
   font-size: 16px;
@@ -202,3 +240,57 @@ input[type="password"] {
   text-decoration: underline;
 }
 
+/* 모달 전체 배경 */
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+/* 모달 내용 */
+.modal-content {
+  background-color: white;
+  margin: 20% auto;
+  padding: 30px;
+  border-radius: 8px;
+  width: 520px;
+  height: 250px; 
+  position: relative;
+  text-align: center; /* 텍스트를 중앙에 정렬 */
+}
+
+/* 모달 텍스트 */
+.modalmessage {
+  font-family: 'Pretendard';
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 19.09px;
+  text-align: center;
+  color:  #1F2937;/* 텍스트 색상 */
+  margin-bottom: 30px;
+}
+
+/* 확인 버튼 */
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.close-modal-btn {
+  font-family: 'Pretendard';
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 19.09px;
+  background-color: #3692FF; /* 파란색 버튼 */
+  color: white;
+  border: none;
+  padding: 12px 23px 12px 23px;
+  gap: 10px;
+  border-radius: 8px;
+  cursor: pointer;
+}

--- a/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/register.css
+++ b/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/register.css
@@ -70,7 +70,36 @@ body {
   justify-content: space-between;
 }
 
+.input-group1 input.error {
+  border: 1px solid red;
+}
 
+.error-message-mail {
+  font-family: 'Pretendard';
+  display: flex;
+  justify-content: space-between;
+  color: #F74747;
+  font-size: 15px;
+  visibility: hidden;
+  margin-top: 8px;
+  line-height: 17.9px;
+  font-weight: 600;
+}
+
+
+.error-message-password {
+  font-family: 'Pretendard';
+  display: flex;
+  justify-content: space-between;
+  color: #F74747;
+  font-size: 15px;
+  visibility: hidden;
+  margin-top: 8px;
+  line-height: 17.9px;
+  font-weight: 600;
+  position: absolute;
+  bottom: -20px;
+}
 
 .input-group2 input {
   width: 640px;
@@ -89,6 +118,21 @@ body {
   display: flex;
   justify-content: space-between;
 }
+
+input[type="password"] {
+  flex: 1;
+  border: none;
+  outline: none; 
+  padding: 8px; 
+  font-size: 16px; 
+  color: #808080; 
+}
+
+input[type="password"] {
+  padding-right: 40px; /* 토글 버튼이 겹치지 않도록 여유 공간 추가 */
+}
+
+
 .input-group3 {
   width: 640px;
   height: 56px;
@@ -188,14 +232,14 @@ body {
   top: 480px ;
 }
 
-.join-btn {
+.register-btn {
   width: 640px;
   height: 56px;
   background-color: #9CA3AF;
   font-family: 'Pretendard';
   color: white;
   font-size: 20px;
-  font-weight: 600px;
+  font-weight: 600;
   padding: 16px 124px 16px 124px;
   border: none;
   border-radius: 5px;
@@ -204,6 +248,12 @@ body {
   margin-bottom: 20px;
   border-radius: 40px;
   margin-top: 24px;
+}
+
+.register-btn.active {
+  background-color: #3692FF; /* 활성화 상태에서 파란색 */
+  cursor: pointer; /* 활성화 상태에서 클릭 가능 */
+  opacity: 1;
 }
 
 .social-login {
@@ -261,6 +311,66 @@ body {
   line-height: 16.71px;
   color: #3182F6;
   text-decoration: underline;
+}
+
+
+/* 모달 전체 배경 */
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+/* 모달 내용 */
+.modal-content {
+  background-color: white;
+  margin: 20% auto;
+  padding: 30px;
+  border-radius: 8px;
+  width: 520px;
+  height: 250px; 
+  position: relative;
+  text-align: center; /* 텍스트를 중앙에 정렬 */
+}
+
+/* 모달 텍스트 */
+.modal-text {
+  font-family: 'Pretendard';
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 19.09px;
+  text-align: center;
+  color:  #1F2937;/* 텍스트 색상 */
+  margin-bottom: 30px;
+}
+
+/* 확인 버튼 */
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.close-modal-btn {
+  font-family: 'Pretendard';
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 19.09px;
+  background-color: #3692FF; /* 파란색 버튼 */
+  color: white;
+  border: none;
+  padding: 12px 23px 12px 23px;
+  gap: 10px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.close-modal-btn:hover {
+  background-color: #155abc; /* 버튼에 hover 시 색상 변경 */
 }
 
 

--- a/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/register.html
+++ b/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/register.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="kr">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>회원가입</title>
-  <link rel="stylesheet" href="join.css">
+  <link rel="stylesheet" href="register.css">
 </head>
 <body>
   <div class="login-container">
@@ -18,29 +18,32 @@
         <div class="input-group1">
             <div class="putemail">
               <input type="email" id="email" placeholder="이메일을 입력해주세요" required>
+              <span class="error-message-mail" id="emailError"></span>
             </div>
         </div>
         <div class="tinyhead">닉네임</div>
         <div class="input-group2">
-            <input type="email" id="email" placeholder="닉네임을 입력해주세요" required>
-              <button type="button" class="toggle-password"></button>
+            <input type="nickname" id="nickname" placeholder="닉네임을 입력해주세요" required>
+          
         </div>
 
         <div class="tinyhead">비밀번호</div>
         <div class="input-group3">
             <input type="password" id="password" placeholder="비밀번호를 입력해주세요" required>
+            <span class="error-message-password" id="passwordError"></span>
             <button type="button" class="toggle-password"> <img src="btn_visibility_on_24px.png" alt="토글패스워드">
             </button>        
           </div>
 
         <div class="tinyhead">비밀번호 확인</div>
         <div class="input-group4">
-            <input type="password" id="password" placeholder="비밀번호를 입력해주세요" required>
+            <input type="password" id="passwordConfirm" placeholder="비밀번호를 입력해주세요" required>
+            <span class="error-message-password" id="passwordConfirmError"></span>
             <button type="button" class="toggle-password"> <img src="btn_visibility_on_24px.png" alt="토글패스워드">
             </button>       
            </div>
     
-        <button type="submit" class="join-btn">회원가입</button>
+        <button type="submit" class="register-btn" disabled>회원가입</button>
 
 
         <!--간편로그인-->
@@ -62,8 +65,19 @@
         </p>
     </form>
 </div>
+<div id="modal" class="modal">
+  <div class="modal-content">
+    <p id="modalMessage" class="modal-text">사용 중인 이메일입니다.</p>
+    <div class="modal-footer">
+      <button class="close-modal-btn">확인</button>
+    </div> 
+  </div>
+</div>
 
-<script src="join.js"></script>
+
+
+
+<script src="register2.js"></script>
 
 </body>
 </html>

--- a/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/register2.js
+++ b/스프린트미션_1&2_하신혜/스프린트 미션_1&2_하신혜/register2.js
@@ -1,0 +1,167 @@
+// 비밀번호 토글
+document.querySelectorAll('.toggle-password').forEach(function (button) {
+  button.addEventListener('click', function () {
+    const passwordInput = this.parentElement.querySelector('input[type="password"], input[type="text"]');
+    const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
+    passwordInput.setAttribute('type', type);
+
+    this.querySelector('img').alt = type === 'password' ? '토글패스워드' : '비밀번호 숨기기';
+  });
+});
+
+// 이메일, 비밀번호, 비밀번호 확인 유효성 검사 및 회원가입 버튼 활성화
+function validateForm() {
+  const emailInput = document.getElementById('email');
+  const passwordInput = document.getElementById('password');
+  const confirmPasswordInput = document.getElementById('passwordConfirm');
+  const registerButton = document.querySelector('.register-btn');
+
+  const emailValue = emailInput.value.trim();
+  const passwordValue = passwordInput.value.trim();
+  const confirmPasswordValue = confirmPasswordInput.value.trim();
+
+  const emailError = document.getElementById('emailError');
+  const passwordError = document.getElementById('passwordError');
+  const confirmPasswordError = document.getElementById('passwordConfirmError');
+
+  const emailPattern = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+  let isValid = true;
+
+  // 이메일 유효성 검사
+  if (!emailValue) {
+    emailInput.classList.add('error');
+    emailError.textContent = '이메일을 입력해주세요.';
+    emailError.style.visibility = 'visible';
+    isValid = false;
+  } else if (!emailPattern.test(emailValue)) {
+    emailInput.classList.add('error');
+    emailError.textContent = '잘못된 이메일 형식입니다.';
+    emailError.style.visibility = 'visible';
+    isValid = false;
+  } else {
+    emailInput.classList.remove('error');
+    emailError.style.visibility = 'hidden';
+  }
+
+  // 비밀번호 유효성 검사
+  if (!passwordValue) {
+    passwordInput.classList.add('error');
+    passwordError.textContent = '비밀번호를 입력해주세요.';
+    passwordError.style.visibility = 'visible';
+    isValid = false;
+  } else if (passwordValue.length < 8) {
+    passwordInput.classList.add('error');
+    passwordError.textContent = '비밀번호를 8자 이상 입력해주세요.';
+    passwordError.style.visibility = 'visible';
+    isValid = false;
+  } else {
+    passwordInput.classList.remove('error');
+    passwordError.style.visibility = 'hidden';
+  }
+
+  // 비밀번호 확인 유효성 검사
+  if (!confirmPasswordValue) {
+    confirmPasswordInput.classList.add('error');
+    confirmPasswordError.textContent = '비밀번호 확인을 입력해주세요.';
+    confirmPasswordError.style.visibility = 'visible';
+    isValid = false;
+  } else if (passwordValue !== confirmPasswordValue) {
+    confirmPasswordInput.classList.add('error');
+    confirmPasswordError.textContent = '비밀번호가 일치하지 않습니다.';
+    confirmPasswordError.style.visibility = 'visible';
+    isValid = false;
+  } else {
+    confirmPasswordInput.classList.remove('error');
+    confirmPasswordError.style.visibility = 'hidden';
+  }
+
+  // 회원가입 버튼 활성화/비활성화
+  registerButton.disabled = !isValid;
+  if (isValid) {
+    registerButton.classList.add('active');
+  } else {
+    registerButton.classList.remove('active');
+  }
+}
+
+// 각 필드에 유효성 검사 이벤트 추가
+document.getElementById('email').addEventListener('input', validateForm);
+document.getElementById('password').addEventListener('input', validateForm);
+document.getElementById('passwordConfirm').addEventListener('input', validateForm);
+
+// 회원가입 버튼 클릭 시 조건 확인 후 페이지 이동
+document.querySelector('.register-btn').addEventListener('click', function () {
+  const registerButton = document.querySelector('.register-btn');
+
+  // 버튼이 활성화되어 있을 때만 이동
+  if (!registerButton.disabled) {
+    window.location.href = '/items'; // '/items'로 페이지 이동
+  }
+});
+
+
+// 유저 데이터베이스
+const USER_DATA = [
+  { email: 'codeit1@codeit.com', password: 'codeit101!' },
+  { email: 'codeit2@codeit.com', password: 'codeit202!' },
+  { email: 'codeit3@codeit.com', password: 'codeit303!' },
+  { email: 'codeit4@codeit.com', password: 'codeit404!' },
+  { email: 'codeit5@codeit.com', password: 'codeit505!' },
+  { email: 'codeit6@codeit.com', password: 'codeit606!' }
+];
+
+
+
+// 회원가입 처리 함수
+function handleSignup() {
+  // 폼 입력 값 가져오기
+  const emailInput = document.getElementById('email').value.trim();
+  const nicknameInput = document.getElementById('nickname').value.trim();
+  const passwordInput = document.getElementById('password').value.trim();
+  const confirmPasswordInput = document.getElementById('passwordConfirm').value.trim();
+
+  // 이메일 중복 체크
+  const isEmailTaken = USER_DATA.some(user => user.email === emailInput);
+
+  if (isEmailTaken) {
+    // 이메일이 이미 존재하는 경우
+    openModal('사용 중인 이메일입니다');
+  } else if (passwordInput !== confirmPasswordInput) {
+    // 비밀번호 확인이 일치하지 않는 경우
+    openModal('비밀번호가 일치하지 않습니다.');
+  } else if (passwordInput.length < 8) {
+    // 비밀번호가 8자 이상이 아닌 경우
+    openModal('비밀번호는 8자 이상이어야 합니다.');
+  } else {
+    // 회원가입 성공 처리
+    // 새로운 유저 데이터 추가 (가짜로 처리)
+    USER_DATA.push({ email: emailInput, password: passwordInput });
+
+    // 성공 메시지 표시 및 로그인 페이지로 이동
+    openModal('회원가입이 성공적으로 처리되었습니다');
+
+    window.location.href = '/login'; // 로그인 페이지로 이동
+  }
+}
+
+// 모달 요소 가져오기
+const modal = document.getElementById('modal');
+const modalMessage = document.getElementById('modalMessage');
+const closeModal = document.querySelector('.close-modal-btn');
+
+// 모달 열기 함수
+function openModal(message) {
+  modalMessage.textContent = message; // 전달된 메시지를 모달에 표시
+  modal.style.display = 'block'; // 모달을 보이게 설정
+}
+
+// 모달 닫기 함수
+closeModal.addEventListener('click', function() {
+  modal.style.display = 'none';
+});
+
+
+// 회원가입 버튼 클릭 시 실행
+document.querySelector('.register-btn').addEventListener('click', handleSignup);
+


### PR DESCRIPTION
### 기본 요구사항
공통
 - [x] Github에 스프린트 미션 PR을 만들어 주세요.
- [x] 로그인, 회원가입 페이지 공통
- [x] 로그인 및 회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요.
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] - [ ]비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x]  input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [x] Input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다
     const USER_DATA = [
     { email: 'codeit1@codeit.com', password: "codeit101!" },
     { email: 'codeit2@codeit.com', password: "codeit202!" },
     { email: 'codeit3@codeit.com', password: "codeit303!" },
     { email: 'codeit4@codeit.com', password: "codeit404!" },
     { email: 'codeit5@codeit.com', password: "codeit505!" },
    { email: 'codeit6@codeit.com', password: "codeit606!" },
];
### 로그인 페이지
- [x] 이메일과 비밀번호를 입력하고 로그인 버튼을 누른 후, 다음 조건을 참조하여 로그인 성공 여부를 alert 메시지로 출력합니다.
- [x] 만약 입력한 이메일이 데이터베이스(USER_DATA)에 없거나, 이메일은 일치하지만 비밀번호가 틀린 경우, '비밀번호가 일치하지 않습니다.'라는 메시지를 alert로 표시합니다
- [x] 만약 입력한 이메일이 데이터베이스에 존재하고, 비밀번호도 일치할 경우, “/items”로 이동합니다.
회원가입
- [x] 회원가입을 위해 이메일, 닉네임, 비밀번호, 비밀번호 확인을 입력한 뒤, 회원가입 버튼을 클릭하세요. 그 후에는 다음 조건에 따라 회원가입 가능 여부를 alert로 알려주세요.
- [x] 입력한 이메일이 이미 데이터베이스(USER_DATA)에 존재하는 경우, '사용 중인 이메일입니다'라는 메시지를 alert로 표시합니다.
- [x] 입력한 이메일이 데이터베이스(USER_DATA)에 없는 경우, 회원가입이 성공적으로 처리되었으므로 로그인 페이지(”/login”)로 이동합니다.

###  심화 요구사항
 공통

- [ ]  페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 판다마켓 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정합니다.
- [ ] 미리보기에서 제목은 “판다마켓”, 설명은 “일상에서 모든 물건을 거래해보세요”로 설정합니다.
- [ ]  주소와 이미지는 자유롭게 설정하세요.
- [ ] 로그인, 회원가입 페이지에 공통으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용해 주세요.
###  랜딩 페이지
- [ ] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
- [ ] PC: 1200px 이상
- [ ] Tablet: 744px 이상 ~ 1199px 이하
- [ ] Mobile: 375px 이상 ~ 743px 이하
- [ ] 375px 미만 사이즈의 디자인은 고려하지 않습니다
- [ ] [ ] Tablet 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [ ] [ ] Mobile 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [ ] [ ] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용합니다.
- [ ] [ ] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차게 구현합니다. (이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)
- [ ] [ ] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 사이 간격이 커집니다.

### 로그인, 회원가입 페이지 공통

- [ ] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [ ] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [ ] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.
- [ ] 오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.
- [ ] 비밀번호 및 비밀번호 확인 입력란에 눈 모양 아이콘 클릭 시 비밀번호 표시/숨기기 토글이 가능합니다. 기본 상태는 비밀번호 숨김으로 설정합니다.


## 멘토에게
안녕하세요 존경하는 멘토님.. 심화 부분이 텅텅 빈 것을 보고 상심하셨을거같습니다.. 죄송합니다 😫
1. 시도해 본 방향 또는 계획 
기본적으로 기본 요구사항에 시간 할애를 많이 했습니다. 
저번 스프린트 1/2 과제때 멘션하셨던 부분 간단하게는 수정해보았는데 기존에 작업하던 내용인 만큼 이제와서 클래스 명 바꾸기가 쉽지않아서 이번에는 그대로 작업해보았습니다. 새로 작성한 클래스명은 조금 신경써보았습니다!
2. 막힌 부분 
모달 버튼 관련해서 이해하지 못하고 중도에 포기했습니다 ㅠㅠ 미디어쿼리 관련해서는 관련 강의를 보긴하였으나 적용해보진 못하였습니다. 다음 주에 다 못한 심화과정 시간 날때마다 틈틈히 진행해 볼 예정입니다.
3. 궁금한 점 등
실업무에서도 이렇게 일일히 손으로 다 써야하나요 어흑... 이번 과제때 많이 힘들었습니다 ㅠㅠ

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
